### PR TITLE
Added id generation

### DIFF
--- a/internal/expr/expr_test.go
+++ b/internal/expr/expr_test.go
@@ -46,97 +46,97 @@ var tests = []struct {
 	"SELECT p.* AS &Person.*",
 	"[Bypass[SELECT ] Output[[p.*] [Person.*]]]",
 	[]any{Person{}},
-	"SELECT p.address_id, p.id, p.name",
+	"SELECT p.address_id AS [a-zA-Z_0-9]+, p.id AS [a-zA-Z_0-9]+, p.name AS [a-zA-Z_0-9]+",
 }, {
 	"quoted output expression",
 	"SELECT p.* AS &Person.*, '&notAnOutputExpresion.*' AS literal FROM t",
 	"[Bypass[SELECT ] Output[[p.*] [Person.*]] Bypass[, ] Bypass['&notAnOutputExpresion.*'] Bypass[ AS literal FROM t]]",
 	[]any{Person{}},
-	"SELECT p.address_id, p.id, p.name, '&notAnOutputExpresion.*' AS literal FROM t",
+	"SELECT p.address_id AS [a-zA-Z_0-9]+, p.id AS [a-zA-Z_0-9]+, p.name AS [a-zA-Z_0-9]+, '&notAnOutputExpresion.*' AS literal FROM t",
 }, {
 	"star as output",
 	"SELECT * AS &Person.* FROM t",
 	"[Bypass[SELECT ] Output[[*] [Person.*]] Bypass[ FROM t]]",
 	[]any{Person{}},
-	"SELECT address_id, id, name FROM t",
+	"SELECT address_id AS [a-zA-Z_0-9]+, id AS [a-zA-Z_0-9]+, name AS [a-zA-Z_0-9]+ FROM t",
 }, {
 	"input v1",
 	"SELECT foo, bar FROM table WHERE foo = $Person.id",
 	"[Bypass[SELECT foo, bar FROM table WHERE foo = ] Input[Person.id]]",
 	[]any{Person{}},
-	"SELECT foo, bar FROM table WHERE foo = ?",
+	`SELECT foo, bar FROM table WHERE foo = \?`,
 }, {
 	"input v2",
 	"SELECT p FROM person WHERE p.name = $Person.name",
 	"[Bypass[SELECT p FROM person WHERE p.name = ] Input[Person.name]]",
 	[]any{Person{}},
-	"SELECT p FROM person WHERE p.name = ?",
+	`SELECT p FROM person WHERE p.name = \?`,
 }, {
 	"input v3",
 	"SELECT p.*, a.district FROM person AS p JOIN address AS a ON p.address_id = a.id WHERE p.name = $Person.name",
 	"[Bypass[SELECT p.*, a.district FROM person AS p JOIN address AS a ON p.address_id = a.id WHERE p.name = ] Input[Person.name]]",
 	[]any{Person{}},
-	"SELECT p.*, a.district FROM person AS p JOIN address AS a ON p.address_id = a.id WHERE p.name = ?",
+	`SELECT p.*, a.district FROM person AS p JOIN address AS a ON p.address_id = a.id WHERE p.name = \?`,
 }, {
 	"output and input",
 	"SELECT &Person.* FROM table WHERE foo = $Address.id",
 	"[Bypass[SELECT ] Output[[] [Person.*]] Bypass[ FROM table WHERE foo = ] Input[Address.id]]",
 	[]any{Person{}, Address{}},
-	"SELECT address_id, id, name FROM table WHERE foo = ?",
+	`SELECT address_id AS [a-zA-Z_0-9]+, id AS [a-zA-Z_0-9]+, name AS [a-zA-Z_0-9]+ FROM table WHERE foo = \?`,
 }, {
 	"output and quote",
 	"SELECT foo, bar, &Person.id FROM table WHERE foo = 'xx'",
 	"[Bypass[SELECT foo, bar, ] Output[[] [Person.id]] Bypass[ FROM table WHERE foo = ] Bypass['xx']]",
 	[]any{Person{}},
-	"SELECT foo, bar, id FROM table WHERE foo = 'xx'",
+	"SELECT foo, bar, id AS [a-zA-Z_0-9]+ FROM table WHERE foo = 'xx'",
 }, {
 	"two outputs and quote",
 	"SELECT foo, &Person.id, bar, baz, &Manager.manager_name FROM table WHERE foo = 'xx'",
 	"[Bypass[SELECT foo, ] Output[[] [Person.id]] Bypass[, bar, baz, ] Output[[] [Manager.manager_name]] Bypass[ FROM table WHERE foo = ] Bypass['xx']]",
 	[]any{Person{}, Manager{}},
-	"SELECT foo, id, bar, baz, manager_name FROM table WHERE foo = 'xx'",
+	"SELECT foo, id AS [a-zA-Z_0-9]+, bar, baz, manager_name AS [a-zA-Z_0-9]+ FROM table WHERE foo = 'xx'",
 }, {
 	"star as output and quote",
 	"SELECT * AS &Person.* FROM person WHERE name = 'Fred'",
 	"[Bypass[SELECT ] Output[[*] [Person.*]] Bypass[ FROM person WHERE name = ] Bypass['Fred']]",
 	[]any{Person{}},
-	"SELECT address_id, id, name FROM person WHERE name = 'Fred'",
+	"SELECT address_id AS [a-zA-Z_0-9]+, id AS [a-zA-Z_0-9]+, name AS [a-zA-Z_0-9]+ FROM person WHERE name = 'Fred'",
 }, {
 	"star output and quote",
 	"SELECT &Person.* FROM person WHERE name = 'Fred'",
 	"[Bypass[SELECT ] Output[[] [Person.*]] Bypass[ FROM person WHERE name = ] Bypass['Fred']]",
 	[]any{Person{}},
-	"SELECT address_id, id, name FROM person WHERE name = 'Fred'",
+	"SELECT address_id AS [a-zA-Z_0-9]+, id AS [a-zA-Z_0-9]+, name AS [a-zA-Z_0-9]+ FROM person WHERE name = 'Fred'",
 }, {
 	"two star as outputs and quote",
 	"SELECT * AS &Person.*, a.* AS &Address.* FROM person, address a WHERE name = 'Fred'",
 	"[Bypass[SELECT ] Output[[*] [Person.*]] Bypass[, ] Output[[a.*] [Address.*]] Bypass[ FROM person, address a WHERE name = ] Bypass['Fred']]",
 	[]any{Person{}, Address{}},
-	"SELECT address_id, id, name, a.district, a.id, a.street FROM person, address a WHERE name = 'Fred'",
+	"SELECT address_id AS [a-zA-Z_0-9]+, id AS [a-zA-Z_0-9]+, name AS [a-zA-Z_0-9]+, a.district AS [a-zA-Z_0-9]+, a.id AS [a-zA-Z_0-9]+, a.street AS [a-zA-Z_0-9]+ FROM person, address a WHERE name = 'Fred'",
 }, {
 	"multicolumn output v1",
 	"SELECT (a.district, a.street) AS (&Address.district, &Address.street) FROM address AS a",
 	"[Bypass[SELECT ] Output[[a.district a.street] [Address.district Address.street]] Bypass[ FROM address AS a]]",
 	[]any{Address{}, District{}},
-	"SELECT a.district, a.street FROM address AS a",
+	"SELECT a.district AS [a-zA-Z_0-9]+, a.street AS [a-zA-Z_0-9]+ FROM address AS a",
 }, {
 	"multicolumn output v2",
 	"SELECT (a.district, a.street) AS (&Address.district, &Address.street), a.id AS &Person.id FROM address AS a",
 	"[Bypass[SELECT ] Output[[a.district a.street] [Address.district Address.street]] Bypass[, ] Output[[a.id] [Person.id]] Bypass[ FROM address AS a]]",
 	[]any{Person{}, Address{}},
-	"SELECT a.district, a.street, a.id FROM address AS a",
+	"SELECT a.district AS [a-zA-Z_0-9]+, a.street AS [a-zA-Z_0-9]+, a.id AS [a-zA-Z_0-9]+ FROM address AS a",
 }, {
 	"multicolumn output v3",
 	"SELECT (a.district, a.street) AS (&Address.district, &Address.street), &Person.* FROM address AS a",
 	"[Bypass[SELECT ] Output[[a.district a.street] [Address.district Address.street]] Bypass[, ] Output[[] [Person.*]] Bypass[ FROM address AS a]]",
 	[]any{Person{}, Address{}},
-	"SELECT a.district, a.street, address_id, id, name FROM address AS a",
+	"SELECT a.district AS [a-zA-Z_0-9]+, a.street AS [a-zA-Z_0-9]+, address_id AS [a-zA-Z_0-9]+, id AS [a-zA-Z_0-9]+, name AS [a-zA-Z_0-9]+ FROM address AS a",
 }, {
 	"multicolumn output v4",
 	"SELECT (a.district, a.street) AS &Address.* FROM address AS a WHERE p.name = 'Fred'",
 	"[Bypass[SELECT ] Output[[a.district a.street] [Address.*]] Bypass[ FROM address AS a WHERE p.name = ] Bypass['Fred']]",
 	[]any{Address{}},
-	"SELECT a.district, a.street FROM address AS a WHERE p.name = 'Fred'",
+	"SELECT a.district AS [a-zA-Z_0-9]+, a.street AS [a-zA-Z_0-9]+ FROM address AS a WHERE p.name = 'Fred'",
 }, {
 	"quote",
 	"SELECT 1 FROM person WHERE p.name = 'Fred'",
@@ -148,43 +148,43 @@ var tests = []struct {
 	"SELECT p.* AS &Person.*, (a.district, a.street) AS &Address.*, (5+7), (col1 * col2) AS calculated_value FROM person AS p JOIN address AS a ON p.address_id = a.id WHERE p.name = 'Fred'",
 	"[Bypass[SELECT ] Output[[p.*] [Person.*]] Bypass[, ] Output[[a.district a.street] [Address.*]] Bypass[, (5+7), (col1 * col2) AS calculated_value FROM person AS p JOIN address AS a ON p.address_id = a.id WHERE p.name = ] Bypass['Fred']]",
 	[]any{Person{}, Address{}},
-	"SELECT p.address_id, p.id, p.name, a.district, a.street, (5+7), (col1 * col2) AS calculated_value FROM person AS p JOIN address AS a ON p.address_id = a.id WHERE p.name = 'Fred'",
+	`SELECT p.address_id AS [a-zA-Z_0-9]+, p.id AS [a-zA-Z_0-9]+, p.name AS [a-zA-Z_0-9]+, a.district AS [a-zA-Z_0-9]+, a.street AS [a-zA-Z_0-9]+, \(5\+7\), \(col1 \* col2\) AS calculated_value FROM person AS p JOIN address AS a ON p.address_id = a.id WHERE p.name = 'Fred'`,
 }, {
 	"complex query v2",
 	"SELECT p.* AS &Person.*, (a.district, a.street) AS &Address.* FROM person AS p JOIN address AS a ON p .address_id = a.id WHERE p.name = 'Fred'",
 	"[Bypass[SELECT ] Output[[p.*] [Person.*]] Bypass[, ] Output[[a.district a.street] [Address.*]] Bypass[ FROM person AS p JOIN address AS a ON p .address_id = a.id WHERE p.name = ] Bypass['Fred']]",
 	[]any{Person{}, Address{}},
-	"SELECT p.address_id, p.id, p.name, a.district, a.street FROM person AS p JOIN address AS a ON p .address_id = a.id WHERE p.name = 'Fred'",
+	"SELECT p.address_id AS [a-zA-Z_0-9]+, p.id AS [a-zA-Z_0-9]+, p.name AS [a-zA-Z_0-9]+, a.district AS [a-zA-Z_0-9]+, a.street AS [a-zA-Z_0-9]+ FROM person AS p JOIN address AS a ON p .address_id = a.id WHERE p.name = 'Fred'",
 }, {
 	"complex query v3",
 	"SELECT p.* AS &Person.*, (a.district, a.street) AS &Address.* FROM person AS p JOIN address AS a ON p.address_id = a.id WHERE p.name IN (SELECT name FROM table WHERE table.n = $Person.name)",
 	"[Bypass[SELECT ] Output[[p.*] [Person.*]] Bypass[, ] Output[[a.district a.street] [Address.*]] Bypass[ FROM person AS p JOIN address AS a ON p.address_id = a.id WHERE p.name IN (SELECT name FROM table WHERE table.n = ] Input[Person.name] Bypass[)]]",
 	[]any{Person{}, Address{}},
-	"SELECT p.address_id, p.id, p.name, a.district, a.street FROM person AS p JOIN address AS a ON p.address_id = a.id WHERE p.name IN (SELECT name FROM table WHERE table.n = ?)",
+	`SELECT p.address_id AS [a-zA-Z_0-9]+, p.id AS [a-zA-Z_0-9]+, p.name AS [a-zA-Z_0-9]+, a.district AS [a-zA-Z_0-9]+, a.street AS [a-zA-Z_0-9]+ FROM person AS p JOIN address AS a ON p.address_id = a.id WHERE p.name IN \(SELECT name FROM table WHERE table.n = \?\)`,
 }, {
 	"complex query v4",
 	"SELECT p.* AS &Person.*, (a.district, a.street) AS &Address.* FROM person WHERE p.name IN (SELECT name FROM table WHERE table.n = $Person.name) UNION SELECT p.* AS &Person.*, (a.district, a.street) AS &Address.* FROM person WHERE p.name IN (SELECT name FROM table WHERE table.n = $Person.name)",
 	"[Bypass[SELECT ] Output[[p.*] [Person.*]] Bypass[, ] Output[[a.district a.street] [Address.*]] Bypass[ FROM person WHERE p.name IN (SELECT name FROM table WHERE table.n = ] Input[Person.name] Bypass[) UNION SELECT ] Output[[p.*] [Person.*]] Bypass[, ] Output[[a.district a.street] [Address.*]] Bypass[ FROM person WHERE p.name IN (SELECT name FROM table WHERE table.n = ] Input[Person.name] Bypass[)]]",
 	[]any{Person{}, Address{}},
-	"SELECT p.address_id, p.id, p.name, a.district, a.street FROM person WHERE p.name IN (SELECT name FROM table WHERE table.n = ?) UNION SELECT p.address_id, p.id, p.name, a.district, a.street FROM person WHERE p.name IN (SELECT name FROM table WHERE table.n = ?)",
+	`SELECT p.address_id AS [a-zA-Z_0-9]+, p.id AS [a-zA-Z_0-9]+, p.name AS [a-zA-Z_0-9]+, a.district AS [a-zA-Z_0-9]+, a.street AS [a-zA-Z_0-9]+ FROM person WHERE p.name IN \(SELECT name FROM table WHERE table.n = \?\) UNION SELECT p.address_id AS [a-zA-Z_0-9]+, p.id AS [a-zA-Z_0-9]+, p.name AS [a-zA-Z_0-9]+, a.district AS [a-zA-Z_0-9]+, a.street AS [a-zA-Z_0-9]+ FROM person WHERE p.name IN \(SELECT name FROM table WHERE table.n = \?\)`,
 }, {
 	"complex query v5",
 	"SELECT p.* AS &Person.*, &District.* FROM person AS p JOIN address AS a ON p.address_id = a.id WHERE p.name = $Person.name AND p.address_id = $Person.address_id",
 	"[Bypass[SELECT ] Output[[p.*] [Person.*]] Bypass[, ] Output[[] [District.*]] Bypass[ FROM person AS p JOIN address AS a ON p.address_id = a.id WHERE p.name = ] Input[Person.name] Bypass[ AND p.address_id = ] Input[Person.address_id]]",
 	[]any{Person{}, District{}},
-	"SELECT p.address_id, p.id, p.name,  FROM person AS p JOIN address AS a ON p.address_id = a.id WHERE p.name = ? AND p.address_id = ?",
+	`SELECT p.address_id AS [a-zA-Z_0-9]+, p.id AS [a-zA-Z_0-9]+, p.name AS [a-zA-Z_0-9]+,  FROM person AS p JOIN address AS a ON p.address_id = a.id WHERE p.name = \? AND p.address_id = \?`,
 }, {
 	"complex query v6",
 	"SELECT p.* AS &Person.*, FROM person AS p INNER JOIN address AS a ON p.address_id = $Address.id WHERE p.name = $Person.name AND p.address_id = $Person.address_id",
 	"[Bypass[SELECT ] Output[[p.*] [Person.*]] Bypass[, FROM person AS p INNER JOIN address AS a ON p.address_id = ] Input[Address.id] Bypass[ WHERE p.name = ] Input[Person.name] Bypass[ AND p.address_id = ] Input[Person.address_id]]",
 	[]any{Person{}, Address{}},
-	"SELECT p.address_id, p.id, p.name, FROM person AS p INNER JOIN address AS a ON p.address_id = ? WHERE p.name = ? AND p.address_id = ?",
+	`SELECT p.address_id AS [a-zA-Z_0-9]+, p.id AS [a-zA-Z_0-9]+, p.name AS [a-zA-Z_0-9]+, FROM person AS p INNER JOIN address AS a ON p.address_id = \? WHERE p.name = \? AND p.address_id = \?`,
 }, {
 	"join v1",
 	"SELECT p.* AS &Person.*, m.* AS &Manager.* FROM person AS p JOIN person AS m ON p.manager_id = m.id WHERE p.name = 'Fred'",
 	"[Bypass[SELECT ] Output[[p.*] [Person.*]] Bypass[, ] Output[[m.*] [Manager.*]] Bypass[ FROM person AS p JOIN person AS m ON p.manager_id = m.id WHERE p.name = ] Bypass['Fred']]",
 	[]any{Person{}, Manager{}},
-	"SELECT p.address_id, p.id, p.name, m.manager_name FROM person AS p JOIN person AS m ON p.manager_id = m.id WHERE p.name = 'Fred'",
+	"SELECT p.address_id AS [a-zA-Z_0-9]+, p.id AS [a-zA-Z_0-9]+, p.name AS [a-zA-Z_0-9]+, m.manager_name AS [a-zA-Z_0-9]+ FROM person AS p JOIN person AS m ON p.manager_id = m.id WHERE p.name = 'Fred'",
 }, {
 	"join v2",
 	"SELECT person.*, address.district FROM person JOIN address ON person.address_id = address.id WHERE person.name = 'Fred'",
@@ -196,31 +196,31 @@ var tests = []struct {
 	"INSERT INTO person (name) VALUES $Person.name",
 	"[Bypass[INSERT INTO person (name) VALUES ] Input[Person.name]]",
 	[]any{Person{}},
-	"INSERT INTO person (name) VALUES ?",
+	`INSERT INTO person \(name\) VALUES \?`,
 }, {
 	"ignore dollar v1",
 	"SELECT $ FROM moneytable",
 	"[Bypass[SELECT $ FROM moneytable]]",
 	[]any{},
-	"SELECT $ FROM moneytable",
+	`SELECT \$ FROM moneytable`,
 }, {
 	"ignore dollar v2",
 	"SELECT foo FROM data$",
 	"[Bypass[SELECT foo FROM data$]]",
 	[]any{},
-	"SELECT foo FROM data$",
+	`SELECT foo FROM data\$`,
 }, {
 	"ignore dollar v3",
 	"SELECT dollerrow$ FROM moneytable",
 	"[Bypass[SELECT dollerrow$ FROM moneytable]]",
 	[]any{},
-	"SELECT dollerrow$ FROM moneytable",
+	`SELECT dollerrow\$ FROM moneytable`,
 }, {
 	"input with no space",
 	"SELECT p.*, a.district FROM person AS p WHERE p.name=$Person.name",
 	"[Bypass[SELECT p.*, a.district FROM person AS p WHERE p.name=] Input[Person.name]]",
 	[]any{Person{}},
-	"SELECT p.*, a.district FROM person AS p WHERE p.name=?",
+	`SELECT p.*, a.district FROM person AS p WHERE p.name=\?`,
 }, {
 	"escaped double quote",
 	`SELECT foo FROM t WHERE t.p = "Jimmy ""Quickfingers"" Jones"`,
@@ -238,13 +238,13 @@ var tests = []struct {
 	`SELECT * AS &Person.* FROM person WHERE name IN ('Lorn', 'Onos T''oolan', '', ''' ''');`,
 	`[Bypass[SELECT ] Output[[*] [Person.*]] Bypass[ FROM person WHERE name IN (] Bypass['Lorn'] Bypass[, ] Bypass['Onos T''oolan'] Bypass[, ] Bypass[''] Bypass[, ] Bypass[''' '''] Bypass[);]]`,
 	[]any{Person{}},
-	`SELECT address_id, id, name FROM person WHERE name IN ('Lorn', 'Onos T''oolan', '', ''' ''');`,
+	`SELECT address_id AS [a-zA-Z_0-9]+, id AS [a-zA-Z_0-9]+, name AS [a-zA-Z_0-9]+ FROM person WHERE name IN \('Lorn', 'Onos T''oolan', '', ''' '''\);`,
 }, {
 	"update",
 	"UPDATE person SET person.address_id = $Address.id WHERE person.id = $Person.id",
 	"[Bypass[UPDATE person SET person.address_id = ] Input[Address.id] Bypass[ WHERE person.id = ] Input[Person.id]]",
 	[]any{Person{}, Address{}},
-	"UPDATE person SET person.address_id = ? WHERE person.id = ?",
+	`UPDATE person SET person.address_id = \? WHERE person.id = \?`,
 }}
 
 func (s *ExprSuite) TestRound(c *C) {
@@ -263,8 +263,9 @@ func (s *ExprSuite) TestRound(c *C) {
 
 		if preparedExpr, err = parsedExpr.Prepare(test.prepareArgs...); err != nil {
 			c.Errorf("test %d failed (Prepare):\nsummary: %s\ninput: %s\nexpected: %s\nerr: %s\n", i, test.summary, test.input, test.expectedPrepared, err)
-		} else if preparedExpr.SQL != test.expectedPrepared {
-			c.Errorf("test %d failed (Prepare):\nsummary: %s\ninput: %s\nexpected: %s\nactual:   %s\n", i, test.summary, test.input, test.expectedPrepared, preparedExpr.SQL)
+		} else {
+			c.Check(preparedExpr.SQL, Matches, test.expectedPrepared,
+				Commentf("test %d failed (Prepare):\nsummary: %s\ninput: %s\nexpected: %s\nactual:   %s\n", i, test.summary, test.input, test.expectedPrepared, preparedExpr.SQL))
 		}
 	}
 }


### PR DESCRIPTION
One problem that we will encounter further down the line is decoding the results from the query. Specifically, working out which column goes in which field of which struct. We have this information in the `OutputPart` but if we dont have unique column names we may get into trouble. A counter to this would be to assign a unique alias to each column we are interested in at the prepare stage. Then a mapping of these column names to the result types could be saved and used at the scan phase to assign the results to the correct location (correct field of the correct struct). This would also allow us to process weird columns such as functions or literals as a future change if requested.

Assign each column we are going to be interested in at the Scan stage a unique id with AS.
```sql
input:                            SELECT p.* AS &Person.*
sql output of old prepare:        SELECT p.address_id, p.id, p.name
sql output of prepare in this PR: SELECT p.address_id AS sqlair_0, p.id AS sqlair_1, p.name AS sqlair_2
```