### PR TITLE
Add omitempty support in INSERT statements

### DIFF
--- a/internal/expr/parts.go
+++ b/internal/expr/parts.go
@@ -43,6 +43,10 @@ func (p *inputPart) String() string {
 
 func (p *inputPart) part() {}
 
+func (p *inputPart) isInsert() bool {
+	return len(p.targetColumns) != 0
+}
+
 // outputPart represents a named target output variable in the SQL expression,
 // as well as the source table and column where it will be read from.
 type outputPart struct {

--- a/internal/expr/prepare.go
+++ b/internal/expr/prepare.go
@@ -301,11 +301,11 @@ func (pe *ParsedExpr) Prepare(args ...any) (expr *PreparedExpr, err error) {
 				return nil, err
 			}
 
-			if !p.isInsert() {
+			if p.isInsert() {
+				sql.WriteString(genInsertSQL(inCols, &inCount))
+			} else {
 				sql.WriteString("@sqlair_" + strconv.Itoa(inCount))
 				inCount += 1
-			} else {
-				sql.WriteString(genInsertSQL(inCols, &inCount))
 			}
 			inputs = append(inputs, typeMembers...)
 		case *outputPart:

--- a/internal/expr/prepare.go
+++ b/internal/expr/prepare.go
@@ -301,7 +301,7 @@ func (pe *ParsedExpr) Prepare(args ...any) (expr *PreparedExpr, err error) {
 				return nil, err
 			}
 
-			if len(p.targetColumns) == 0 {
+			if !p.isInsert() {
 				sql.WriteString("@sqlair_" + strconv.Itoa(inCount))
 				inCount += 1
 			} else {
@@ -343,7 +343,8 @@ func (pe *ParsedExpr) Prepare(args ...any) (expr *PreparedExpr, err error) {
 
 // genInsertSQL generates the SQL for input expressions in INSERT statements.
 // For example, when inserting three columns, it would generate the string:
-//   "(col1, col2, col3) VALUES (@sqlair_1, @sqlair_2, @sqlair_3)"
+//
+//	"(col1, col2, col3) VALUES (@sqlair_1, @sqlair_2, @sqlair_3)"
 func genInsertSQL(columns []fullName, inCount *int) string {
 	var sql bytes.Buffer
 

--- a/package_test.go
+++ b/package_test.go
@@ -1321,3 +1321,52 @@ func (s *PackageSuite) TestIterMethodOrder(c *C) {
 	err = iter.Close()
 	c.Assert(err, IsNil)
 }
+
+type PersonAutoID struct {
+	ID         int    `db:"id,omitempty"`
+	Fullname   string `db:"name"`
+	PostalCode int    `db:"address_id"`
+}
+
+var fredAutoId = PersonAutoID{Fullname: "Fred", PostalCode: 1000}
+var markAutoId = PersonAutoID{Fullname: "Mark", PostalCode: 1500}
+var maryAutoId = PersonAutoID{Fullname: "Mary", PostalCode: 3500}
+var daveAutoId = PersonAutoID{Fullname: "James", PostalCode: 4500}
+var allPeopleAutoId = []PersonAutoID{fredAutoId, markAutoId, maryAutoId, daveAutoId}
+
+func (s *PackageSuite) TestOmitEmpty(c *C) {
+	createPerson, err := sqlair.Prepare(`
+		CREATE TABLE personAutoID (
+			name text,
+			id INTEGER PRIMARY KEY AUTOINCREMENT,
+			address_id integer,
+			email text
+		);
+	`)
+	c.Assert(err, IsNil)
+
+	db, err := createTestDB()
+	err = db.Query(nil, createPerson).Run()
+	c.Assert(err, IsNil)
+	defer dropTables(c, db, "personAutoId")
+
+	insertPerson, err := sqlair.Prepare("INSERT INTO personAutoID (*) VALUES ($PersonAutoID.*)", PersonAutoID{})
+	for _, p := range allPeopleAutoId {
+		err := db.Query(nil, insertPerson, p).Run()
+		c.Assert(err, IsNil)
+	}
+
+	outPeople := []PersonAutoID{}
+	getAllPeople, err := sqlair.Prepare("SELECT * AS &PersonAutoID.* FROM personAutoID ORDER BY id", PersonAutoID{})
+	c.Assert(err, IsNil)
+	err = db.Query(nil, getAllPeople).GetAll(&outPeople)
+	c.Assert(err, IsNil)
+
+	// Assert ID has been populated automatically and in order.
+	for i, p := range outPeople {
+		c.Assert(p.Fullname, Equals, allPeopleAutoId[i].Fullname)
+		c.Assert(p.PostalCode, Equals, allPeopleAutoId[i].PostalCode)
+		// Numeration starts at 1.
+		c.Assert(p.ID, Equals, i+1)
+	}
+}


### PR DESCRIPTION
When `omitempty` tag is present in a struct field and the field is set to the zero value, it will not be included in the INSERT. This way we can support columns which auto increment.

## How does it work internally?
We prepare the statement in the usual way and when supplied the zero value for the field (i.e. 0 for an int that serves as an id), we instead send `nil`.

## Is sending NULL supported in every DB?
No, it is supported in MySQL and in SQLite but not in Postgres. Several DBs instead use `DEFAULT` for this use case, the problem is that SQLite does not. We have decided to use NULL in order to support the current use cases of the library and, in the future, look for another solution.

## Can we just omit the field in the query altogether?
The way the code is structured, we prepare a query in several steps:
1. Replace the SQLair types for standard sql names that we will later use to get the output.
2. Prepare the statement in the DB.
3. For each call, we call the stored statement with the values supplied.

The problem here is that we have to know the number of fields in step 1., prior to knowing the values themselves, which make it impossible to leave out a field if it contains the zero value.

## Alternatives
If we want to support this use case in all the different DBs in the future we could do the following:
* Re-prepare the statement each time we want to set the field with the default being omitting it. The assumption here is that the majority of use cases would be excluding the field, and the performance penalty would be small.
* Open an issue in the std sql library for them to support sending a default value in a prepared statement in a database agnostic way.
* Recognize in SQLair which DB we are working with and use one identifier or the other.