### PR TITLE
Add omitempty support in INSERT statements

### DIFF
--- a/example_omitempty_test.go
+++ b/example_omitempty_test.go
@@ -1,0 +1,59 @@
+package sqlair_test
+
+import (
+	"database/sql"
+	"fmt"
+
+	"github.com/canonical/sqlair"
+)
+
+func Example() {
+	type Person struct {
+		ID         int    `db:"id,omitempty"`
+		Fullname   string `db:"name"`
+		PostalCode int    `db:"postal_code"`
+	}
+
+	fred := Person{Fullname: "Fred", PostalCode: 1000}
+	mark := Person{Fullname: "Mark", PostalCode: 1500}
+	mary := Person{Fullname: "Mary", PostalCode: 3500}
+	dave := Person{Fullname: "James", PostalCode: 4500}
+	allPeople := []Person{fred, mark, mary, dave}
+
+	sqldb, err := sql.Open("sqlite3", ":memory:")
+	if err != nil {
+		panic(err)
+	}
+	db := sqlair.NewDB(sqldb)
+
+	createPerson := sqlair.MustPrepare(`
+		CREATE TABLE person (
+			id INTEGER PRIMARY KEY AUTOINCREMENT,
+			name text,
+			postal_code integer
+		);
+	`)
+	err = db.Query(nil, createPerson).Run()
+	if err != nil {
+		panic(err)
+	}
+
+	insertPerson := sqlair.MustPrepare("INSERT INTO person (*) VALUES ($Person.*)", Person{})
+	for _, p := range allPeople {
+		err := db.Query(nil, insertPerson, p).Run()
+		if err != nil {
+			panic(err)
+		}
+	}
+
+	outPeople := []Person{}
+	getAllPeople := sqlair.MustPrepare("SELECT * AS &Person.* FROM person ORDER BY id", Person{})
+	err = db.Query(nil, getAllPeople).GetAll(&outPeople)
+	if err != nil {
+		panic(err)
+	}
+	fmt.Println(outPeople)
+
+	// Output:
+	// [{1 Fred 1000} {2 Mark 1500} {3 Mary 3500} {4 James 4500}]
+}

--- a/example_omitempty_test.go
+++ b/example_omitempty_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/canonical/sqlair"
 )
 
-func Example() {
+func Example_omitempty() {
 	type Person struct {
 		ID         int    `db:"id,omitempty"`
 		Fullname   string `db:"name"`
@@ -20,7 +20,7 @@ func Example() {
 	dave := Person{Fullname: "James", PostalCode: 4500}
 	allPeople := []Person{fred, mark, mary, dave}
 
-	sqldb, err := sql.Open("sqlite3", ":memory:")
+	sqldb, err := sql.Open("sqlite3", "file:exampleOmitTest.db?cache=shared&mode=memory")
 	if err != nil {
 		panic(err)
 	}
@@ -37,6 +37,16 @@ func Example() {
 	if err != nil {
 		panic(err)
 	}
+	defer func() {
+		stmt, err := sqlair.Prepare("DROP TABLE person")
+		if err != nil {
+			panic(err)
+		}
+		err = db.Query(nil, stmt).Run()
+		if err != nil {
+			panic(err)
+		}
+	}()
 
 	insertPerson := sqlair.MustPrepare("INSERT INTO person (*) VALUES ($Person.*)", Person{})
 	for _, p := range allPeople {

--- a/internal/expr/parts.go
+++ b/internal/expr/parts.go
@@ -43,6 +43,10 @@ func (p *inputPart) String() string {
 
 func (p *inputPart) part() {}
 
+func (p *inputPart) isInsert() bool {
+	return len(p.targetColumns) != 0
+}
+
 // outputPart represents a named target output variable in the SQL expression,
 // as well as the source table and column where it will be read from.
 type outputPart struct {

--- a/internal/expr/prepare.go
+++ b/internal/expr/prepare.go
@@ -216,7 +216,7 @@ func prepareInput(ti typeNameToInfo, p *inputPart) (inCols []fullName, inputType
 		if err != nil {
 			return nil, nil, err
 		}
-		return []fullName{}, []inputTypeMember{inputTypeMember{typ: tm, sqlContext: None}}, nil
+		return []fullName{}, []inputTypeMember{{typeMember: tm, isInsert: false}}, nil
 	}
 
 	// Prepare input expressions in insert statements.
@@ -231,7 +231,7 @@ func prepareInput(ti typeNameToInfo, p *inputPart) (inCols []fullName, inputType
 	}
 	inputTypeMembers = make([]inputTypeMember, len(typeMembers))
 	for i, t := range typeMembers {
-		inputTypeMembers[i] = inputTypeMember{typ: t, sqlContext: INSERT}
+		inputTypeMembers[i] = inputTypeMember{typeMember: t, isInsert: true}
 	}
 
 	columnInInput := make(map[fullName]bool)

--- a/internal/expr/query.go
+++ b/internal/expr/query.go
@@ -38,7 +38,7 @@ func (pe *PreparedExpr) Query(args ...any) (ce *QueryExpr, err error) {
 
 	var inQuery = make(map[reflect.Type]bool)
 	for _, typeMember := range pe.inputs {
-		inQuery[typeMember.outerType()] = true
+		inQuery[typeMember.typ.outerType()] = true
 	}
 
 	var typeValue = make(map[reflect.Type]reflect.Value)
@@ -60,9 +60,9 @@ func (pe *PreparedExpr) Query(args ...any) (ce *QueryExpr, err error) {
 		typeNames = append(typeNames, t.Name())
 		if !inQuery[t] {
 			// Check if we have a type with the same name from a different package.
-			for _, typeMember := range pe.inputs {
-				if t.Name() == typeMember.outerType().Name() {
-					return nil, fmt.Errorf("type %s not passed as a parameter, have %s", typeMember.outerType().String(), t.String())
+			for _, inputTypeMember := range pe.inputs {
+				if t.Name() == inputTypeMember.typ.outerType().Name() {
+					return nil, fmt.Errorf("type %s not passed as a parameter, have %s", inputTypeMember.typ.outerType().String(), t.String())
 				}
 			}
 			return nil, fmt.Errorf("%s not referenced in query", t.Name())
@@ -71,8 +71,8 @@ func (pe *PreparedExpr) Query(args ...any) (ce *QueryExpr, err error) {
 
 	// Query parameteres.
 	qargs := []any{}
-	for i, typeMember := range pe.inputs {
-		outerType := typeMember.outerType()
+	for i, inputTypeMember := range pe.inputs {
+		outerType := inputTypeMember.typ.outerType()
 		v, ok := typeValue[outerType]
 		if !ok {
 			if len(typeNames) == 0 {
@@ -81,17 +81,23 @@ func (pe *PreparedExpr) Query(args ...any) (ce *QueryExpr, err error) {
 				return nil, fmt.Errorf(`type %q not passed as a parameter, have: %s`, outerType.Name(), strings.Join(typeNames, ", "))
 			}
 		}
-		var val reflect.Value
-		switch tm := typeMember.(type) {
+		var argVal any
+		switch tm := inputTypeMember.typ.(type) {
 		case *structField:
-			val = v.Field(tm.index)
+			val := v.Field(tm.index)
+			if tm.omitEmpty && inputTypeMember.sqlContext == INSERT && val.IsZero() {
+				argVal = nil
+			} else {
+				argVal = val.Interface()
+			}
 		case *mapKey:
-			val = v.MapIndex(reflect.ValueOf(tm.name))
+			val := v.MapIndex(reflect.ValueOf(tm.name))
 			if val.Kind() == reflect.Invalid {
 				return nil, fmt.Errorf(`map %q does not contain key %q`, outerType.Name(), tm.name)
 			}
+			argVal = val.Interface()
 		}
-		qargs = append(qargs, sql.Named("sqlair_"+strconv.Itoa(i), val.Interface()))
+		qargs = append(qargs, sql.Named("sqlair_"+strconv.Itoa(i), argVal))
 	}
 	return &QueryExpr{outputs: pe.outputs, sql: pe.sql, args: qargs}, nil
 }

--- a/internal/expr/typeinfo.go
+++ b/internal/expr/typeinfo.go
@@ -115,16 +115,9 @@ func (mi *mapInfo) getAllMembers() ([]typeMember, error) {
 	return nil, fmt.Errorf(`map type %q cannot be used with asterisk`, mi.mapType.Name())
 }
 
-type sqlContext int
-
-const (
-	None sqlContext = iota
-	INSERT
-)
-
 type inputTypeMember struct {
-	typ        typeMember
-	sqlContext sqlContext
+	isInsert bool
+	typeMember
 }
 
 var _ typeInfo = &mapInfo{}

--- a/internal/expr/typeinfo.go
+++ b/internal/expr/typeinfo.go
@@ -115,6 +115,18 @@ func (mi *mapInfo) getAllMembers() ([]typeMember, error) {
 	return nil, fmt.Errorf(`map type %q cannot be used with asterisk`, mi.mapType.Name())
 }
 
+type sqlContext int
+
+const (
+	None sqlContext = iota
+	INSERT
+)
+
+type inputTypeMember struct {
+	typ        typeMember
+	sqlContext sqlContext
+}
+
 var _ typeInfo = &mapInfo{}
 
 var cacheMutex sync.RWMutex

--- a/package_test.go
+++ b/package_test.go
@@ -1329,11 +1329,11 @@ func (s *PackageSuite) TestOmitEmpty(c *C) {
 		PostalCode int    `db:"postal_code"`
 	}
 
-	var fredAutoId = PersonAutoID{Fullname: "Fred", PostalCode: 1000}
-	var markAutoId = PersonAutoID{Fullname: "Mark", PostalCode: 1500}
-	var maryAutoId = PersonAutoID{Fullname: "Mary", PostalCode: 3500}
-	var daveAutoId = PersonAutoID{Fullname: "James", PostalCode: 4500}
-	var allPeopleAutoId = []PersonAutoID{fredAutoId, markAutoId, maryAutoId, daveAutoId}
+	fredAutoId := PersonAutoID{Fullname: "Fred", PostalCode: 1000}
+	markAutoId := PersonAutoID{Fullname: "Mark", PostalCode: 1500}
+	maryAutoId := PersonAutoID{Fullname: "Mary", PostalCode: 3500}
+	daveAutoId := PersonAutoID{Fullname: "James", PostalCode: 4500}
+	allPeopleAutoId := []PersonAutoID{fredAutoId, markAutoId, maryAutoId, daveAutoId}
 
 	db, err := createTestDB()
 	c.Assert(err, IsNil)

--- a/package_test.go
+++ b/package_test.go
@@ -1322,19 +1322,19 @@ func (s *PackageSuite) TestIterMethodOrder(c *C) {
 	c.Assert(err, IsNil)
 }
 
-type PersonAutoID struct {
-	ID         int    `db:"id,omitempty"`
-	Fullname   string `db:"name"`
-	PostalCode int    `db:"postal_code"`
-}
-
-var fredAutoId = PersonAutoID{Fullname: "Fred", PostalCode: 1000}
-var markAutoId = PersonAutoID{Fullname: "Mark", PostalCode: 1500}
-var maryAutoId = PersonAutoID{Fullname: "Mary", PostalCode: 3500}
-var daveAutoId = PersonAutoID{Fullname: "James", PostalCode: 4500}
-var allPeopleAutoId = []PersonAutoID{fredAutoId, markAutoId, maryAutoId, daveAutoId}
-
 func (s *PackageSuite) TestOmitEmpty(c *C) {
+	type PersonAutoID struct {
+		ID         int    `db:"id,omitempty"`
+		Fullname   string `db:"name"`
+		PostalCode int    `db:"postal_code"`
+	}
+
+	var fredAutoId = PersonAutoID{Fullname: "Fred", PostalCode: 1000}
+	var markAutoId = PersonAutoID{Fullname: "Mark", PostalCode: 1500}
+	var maryAutoId = PersonAutoID{Fullname: "Mary", PostalCode: 3500}
+	var daveAutoId = PersonAutoID{Fullname: "James", PostalCode: 4500}
+	var allPeopleAutoId = []PersonAutoID{fredAutoId, markAutoId, maryAutoId, daveAutoId}
+
 	db, err := createTestDB()
 	c.Assert(err, IsNil)
 
@@ -1348,7 +1348,7 @@ func (s *PackageSuite) TestOmitEmpty(c *C) {
 	c.Assert(err, IsNil)
 	err = db.Query(nil, createPerson).Run()
 	c.Assert(err, IsNil)
-	defer dropTables(c, db, "personAutoId")
+	defer dropTables(c, db, "personAutoID")
 
 	insertPerson, err := sqlair.Prepare("INSERT INTO personAutoID (*) VALUES ($PersonAutoID.*)", PersonAutoID{})
 	for _, p := range allPeopleAutoId {
@@ -1356,26 +1356,28 @@ func (s *PackageSuite) TestOmitEmpty(c *C) {
 		c.Assert(err, IsNil)
 	}
 
+	// Assert that the inserted people got the ID field populated automatically
+	// and in the correct order.
 	outPeople := []PersonAutoID{}
 	getAllPeople, err := sqlair.Prepare("SELECT * AS &PersonAutoID.* FROM personAutoID ORDER BY id", PersonAutoID{})
 	c.Assert(err, IsNil)
 	err = db.Query(nil, getAllPeople).GetAll(&outPeople)
 	c.Assert(err, IsNil)
-	// Assert that ID has been populated automatically and in order.
 	for i, p := range outPeople {
 		c.Assert(p.Fullname, Equals, allPeopleAutoId[i].Fullname)
 		c.Assert(p.PostalCode, Equals, allPeopleAutoId[i].PostalCode)
-		// Numeration starts at 1.
+		// Enumeration starts at 1.
 		c.Assert(p.ID, Equals, i+1)
 	}
 
+	// Assert that using an omitempty field is not actually omitted if it is not
+	// inside an INSERT.
 	personWithId := outPeople[0]
 	outPeople = []PersonAutoID{}
 	getPerson, err := sqlair.Prepare("SELECT * AS &PersonAutoID.* FROM personAutoID WHERE id = $PersonAutoID.id", PersonAutoID{})
 	c.Assert(err, IsNil)
 	err = db.Query(nil, getPerson, personWithId).GetAll(&outPeople)
 	c.Assert(err, IsNil)
-	// Assert that using an omitempty field outside of INSERT does not omit it.
 	c.Assert(outPeople, HasLen, 1)
 	c.Assert(outPeople[0].Fullname, Equals, personWithId.Fullname)
 	c.Assert(outPeople[0].PostalCode, Equals, personWithId.PostalCode)


### PR DESCRIPTION
When `omitempty` tag is present in a struct field and the field is set to the zero value, it will not be included in the INSERT. This way we can support columns which auto increment.

## How does it work internally?
We prepare the statement in the usual way and when supplied the zero value for the field (i.e. 0 for an int that serves as an id) and the field was annotated with `omitempty`, we instead send `nil`.

## Is sending NULL supported in every DB?
No, it is supported in MySQL and in SQLite but not in Postgres. However, the sql Go library does not support sending any other form of default. That is why we have decided to use NULL and in the future we can look for another solution if the need arises.

For context, several DBs instead use `DEFAULT` for this use case, the problem is that SQLite does not.

## Can we just omit the field in the query altogether?
Because of how SQLair works, we prepare a statement before getting the values, meaning we have we have to know the number of fields prior to knowing if we are going to omit any, which makes it impossible to leave out a field directly in Prepare.

## Alternatives
If we want to support this use case in all the different DBs in the future we could do the following:
* [PREFERRED] Re-prepare the statement each time we want to set the field with the default being omitting it. The assumption here is that the majority of use cases would be excluding the field, and the performance penalty would be small.
* Open an issue in the std sql library for them to support sending a default value in a prepared statement in a database agnostic way.
