### PR TITLE
Change slice syntax in IN statements

### DIFF
--- a/internal/expr/expr_test.go
+++ b/internal/expr/expr_test.go
@@ -536,11 +536,15 @@ func (s *ExprSuite) TestPrepareErrors(c *C) {
 	}, {
 		query:       "SELECT name FROM person WHERE id IN ($M.*)",
 		prepareArgs: []any{M{}},
-		err:         `cannot prepare expression: cannot use map "M" with asterisk in output expression: IN ($M.*)`,
+		err:         `cannot prepare expression: cannot use map "M" with asterisk in input expression: IN ($M.*)`,
 	}, {
 		query:       "SELECT name FROM person WHERE id IN ($Person.*)",
 		prepareArgs: []any{Person{}},
-		err:         `cannot prepare expression: cannot use struct "Person" with asterisk in output expression: IN ($Person.*)`,
+		err:         `cannot prepare expression: cannot use struct "Person" with asterisk in input expression: IN ($Person.*)`,
+	}, {
+		query:       "SELECT &S.* FROM t",
+		prepareArgs: []any{S{}},
+		err:         `cannot prepare expression: cannot use slice type "S" in output expression`,
 	}}
 
 	for i, test := range tests {

--- a/internal/expr/expr_test.go
+++ b/internal/expr/expr_test.go
@@ -262,14 +262,14 @@ AND z = @sqlair_0 -- The line with $Person.id on it
 	"SELECT person.*, address.district FROM person JOIN address ON person.address_id = address.id WHERE person.name = 'Fred'",
 }, {
 	"simple in",
-	"SELECT name FROM person WHERE id IN ($S)",
-	"[Bypass[SELECT name FROM person WHERE id ] In[[S]]]",
+	"SELECT name FROM person WHERE id IN ($S.*)",
+	"[Bypass[SELECT name FROM person WHERE id ] In[[S.*]]]",
 	[]any{sqlair.S{}},
 	"SELECT name FROM person WHERE id IN (@sqlair_0, @sqlair_1, @sqlair_2, @sqlair_3, @sqlair_4, @sqlair_5, @sqlair_6, @sqlair_7)",
 }, {
 	"complex in",
-	"SELECT * AS &Person.* FROM person WHERE id IN ($Person.id, $S, $Manager.id, $T, $U)",
-	"[Bypass[SELECT ] Output[[*] [Person.*]] Bypass[ FROM person WHERE id ] In[[Person.id S Manager.id T U]]]",
+	"SELECT * AS &Person.* FROM person WHERE id IN ($Person.id, $S.*, $Manager.id, $T.*, $U.*)",
+	"[Bypass[SELECT ] Output[[*] [Person.*]] Bypass[ FROM person WHERE id ] In[[Person.id S.* Manager.id T.* U.*]]]",
 	[]any{sqlair.S{}, Person{}, Manager{}, T{}, U{}},
 	"SELECT address_id AS _sqlair_0, id AS _sqlair_1, name AS _sqlair_2 FROM person WHERE id IN (@sqlair_0, @sqlair_1, @sqlair_2, @sqlair_3, @sqlair_4, @sqlair_5, @sqlair_6, @sqlair_7, @sqlair_8, @sqlair_9, @sqlair_10, @sqlair_11, @sqlair_12, @sqlair_13, @sqlair_14, @sqlair_15, @sqlair_16, @sqlair_17, @sqlair_18, @sqlair_19, @sqlair_20, @sqlair_21, @sqlair_22, @sqlair_23, @sqlair_24, @sqlair_25)",
 }, {
@@ -397,6 +397,12 @@ func (s *ExprSuite) TestParseErrors(c *C) {
 	}, {
 		query: "SELECT (name, id) AS &Person.*",
 		err:   `cannot parse expression: column 30: missing parentheses around types after "AS"`,
+	}, {
+		query: "SELECT col1 AS &S FROM t",
+		err:   `cannot parse expression: column 17: unqualified type, expected S.* or S.<db tag>`,
+	}, {
+		query: "SELECT * AS &S FROM t",
+		err:   `cannot parse expression: column 14: unqualified type, expected S.* or S.<db tag>`,
 	}}
 
 	for _, t := range tests {
@@ -524,17 +530,17 @@ func (s *ExprSuite) TestPrepareErrors(c *C) {
 		prepareArgs: []any{NoTags{}},
 		err:         `cannot prepare expression: type "NoTags" in "&NoTags.*" does not have any db tags`,
 	}, {
-		query:       "SELECT foo FROM t WHERE x = $S",
+		query:       "SELECT foo FROM t WHERE x = $S.*",
 		prepareArgs: []any{S{}},
 		err:         `cannot prepare expression: cannot use slice type "S" outside of IN clause`,
 	}, {
-		query:       "SELECT col1 AS &S FROM t",
-		prepareArgs: []any{S{}},
-		err:         `cannot prepare expression: cannot use slice type "S" in output expression`,
+		query:       "SELECT name FROM person WHERE id IN ($M.*)",
+		prepareArgs: []any{M{}},
+		err:         `cannot prepare expression: cannot use map "M" with asterisk in output expression: IN ($M.*)`,
 	}, {
-		query:       "SELECT * AS &S FROM t",
-		prepareArgs: []any{S{}},
-		err:         `cannot prepare expression: cannot use slice type "S" in output expression`,
+		query:       "SELECT name FROM person WHERE id IN ($Person.*)",
+		prepareArgs: []any{Person{}},
+		err:         `cannot prepare expression: cannot use struct "Person" with asterisk in output expression: IN ($Person.*)`,
 	}}
 
 	for i, test := range tests {
@@ -644,7 +650,7 @@ func (s *ExprSuite) TestValidQuery(c *C) {
 		[]any{Person{ID: 666}, StringMap{"street": "Highway to Hell"}},
 		[]any{sql.Named("sqlair_0", "Highway to Hell"), sql.Named("sqlair_1", 666)},
 	}, {
-		"SELECT name FROM person WHERE id IN ($S)",
+		"SELECT name FROM person WHERE id IN ($S.*)",
 		[]any{sqlair.S{}},
 		[]any{sqlair.S{1, 2, 3, 4, 5, 6}},
 		[]any{sql.Named("sqlair_0", 1), sql.Named("sqlair_1", 2), sql.Named("sqlair_2", 3), sql.Named("sqlair_3", 4), sql.Named("sqlair_4", 5), sql.Named("sqlair_5", 6), sql.Named("sqlair_6", nil), sql.Named("sqlair_7", nil)},
@@ -727,7 +733,7 @@ func (s *ExprSuite) TestQueryError(c *C) {
 		queryArgs:   []any{Person{}, Person{}},
 		err:         `invalid input parameter: type "Person" provided more than once`,
 	}, {
-		query:       "SELECT street FROM t WHERE x IN ($S)",
+		query:       "SELECT street FROM t WHERE x IN ($S.*)",
 		prepareArgs: []any{S{}},
 		queryArgs:   []any{S{}},
 		err:         `invalid input parameter: slice arg with type "S" has length 0`,

--- a/internal/expr/prepare.go
+++ b/internal/expr/prepare.go
@@ -108,7 +108,7 @@ func prepareIn(ti typeNameToInfo, p *inPart) ([]typeMember, error) {
 		switch info := info.(type) {
 		case *structInfo:
 			if t.name == "*" {
-				return nil, fmt.Errorf(`cannot use struct %q with asterisk in output expression: %s`, t.prefix, p.raw)
+				return nil, fmt.Errorf(`cannot use struct %q with asterisk in input expression: %s`, t.prefix, p.raw)
 			}
 			tm, ok = info.tagToField[t.name]
 			if !ok {
@@ -116,7 +116,7 @@ func prepareIn(ti typeNameToInfo, p *inPart) ([]typeMember, error) {
 			}
 		case *mapInfo:
 			if t.name == "*" {
-				return nil, fmt.Errorf(`cannot use map %q with asterisk in output expression: %s`, t.prefix, p.raw)
+				return nil, fmt.Errorf(`cannot use map %q with asterisk in input expression: %s`, t.prefix, p.raw)
 			}
 			tm = &mapKey{name: t.name, mapType: info.typ()}
 		case *sliceInfo:

--- a/internal/expr/prepare.go
+++ b/internal/expr/prepare.go
@@ -104,17 +104,20 @@ func prepareIn(ti typeNameToInfo, p *inPart) ([]typeMember, error) {
 				return nil, fmt.Errorf(`type %q not passed as a parameter, have: %s`, t.prefix, strings.Join(ts, ", "))
 			}
 		}
-		if t.name == "*" {
-			return nil, fmt.Errorf("invalid asterisk in input expression: %s", p.raw)
-		}
 		var tm typeMember
 		switch info := info.(type) {
 		case *structInfo:
+			if t.name == "*" {
+				return nil, fmt.Errorf(`cannot use struct %q with asterisk in output expression: %s`, t.prefix, p.raw)
+			}
 			tm, ok = info.tagToField[t.name]
 			if !ok {
 				return nil, fmt.Errorf(`type %q has no %q db tag`, info.typ().Name(), t.name)
 			}
 		case *mapInfo:
+			if t.name == "*" {
+				return nil, fmt.Errorf(`cannot use map %q with asterisk in output expression: %s`, t.prefix, p.raw)
+			}
 			tm = &mapKey{name: t.name, mapType: info.typ()}
 		case *sliceInfo:
 			tm = &sliceType{sliceType: info.typ()}

--- a/package_test.go
+++ b/package_test.go
@@ -207,21 +207,21 @@ func (s *PackageSuite) TestValidIterGet(c *C) {
 		expected: [][]any{},
 	}, {
 		summary:  "simple in",
-		query:    "SELECT * AS &Person.* FROM person WHERE id IN ($S)",
+		query:    "SELECT * AS &Person.* FROM person WHERE id IN ($S.*)",
 		types:    []any{Person{}, sqlair.S{}},
 		inputs:   []any{sqlair.S{30, 35, 36, 37, 38, 39, 40}},
 		outputs:  [][]any{{&Person{}}, {&Person{}}, {&Person{}}},
 		expected: [][]any{{&Person{30, "Fred", 1000}}, {&Person{40, "Mary", 3500}}, {&Person{35, "James", 4500}}},
 	}, {
 		summary:  "complex in",
-		query:    "SELECT * AS &Person.* FROM person WHERE id IN ($Person.id, $S, $Manager.id, $T, $U)",
+		query:    "SELECT * AS &Person.* FROM person WHERE id IN ($Person.id, $S.*, $Manager.id, $T.*, $U.*)",
 		types:    []any{Person{}, sqlair.S{}, Manager{}, T{}, U{}},
 		inputs:   []any{Person{ID: 20}, sqlair.S{21, 23, 24, 25, 26, 27, 28, 29}, T{31, 32, 33, 34, 35}, &Manager{ID: 30}, U{"36", "37", "38", "39", "40"}},
 		outputs:  [][]any{{&Person{}}, {&Person{}}, {&Person{}}, {&Person{}}},
 		expected: [][]any{{&Person{30, "Fred", 1000}}, {&Person{20, "Mark", 1500}}, {&Person{40, "Mary", 3500}}, {&Person{35, "James", 4500}}},
 	}, {
 		summary:  "array in",
-		query:    "SELECT * AS &Person.* FROM person WHERE id IN ($V)",
+		query:    "SELECT * AS &Person.* FROM person WHERE id IN ($V.*)",
 		types:    []any{Person{}, V{}},
 		inputs:   []any{V{30, 35, 40}},
 		outputs:  [][]any{{&Person{}}, {&Person{}}, {&Person{}}},
@@ -697,7 +697,7 @@ func (s *PackageSuite) TestValidGetAll(c *C) {
 		expected: []any{&[]sqlair.M{{"name": "Mark"}}, &[]CustomMap{{"id": int64(20)}}},
 	}, {
 		summary:  "simple in",
-		query:    "SELECT * AS &Person.* FROM person WHERE id IN ($S)",
+		query:    "SELECT * AS &Person.* FROM person WHERE id IN ($S.*)",
 		types:    []any{Person{}, sqlair.S{}},
 		inputs:   []any{sqlair.S{20, 35, 36, 37, 38, 39, 40}},
 		slices:   []any{&[]*Person{}},


### PR DESCRIPTION
The syntax for slices becomes $Type.* to be consistent with the rest of the output expressions (previously slices were parsed as $Type instead).